### PR TITLE
Add browserify source transforms

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,5 +37,10 @@
   },
   "dependencies": {
     "traceur": "0.0.90"
+  },
+  "browserify": {
+    "transform": [
+      "babelify"
+    ]
   }
 }


### PR DESCRIPTION
You can configure transforms to be automatically applied when a module is loaded in a package's `browserify.transform` field. 

See: https://github.com/substack/node-browserify#browserifytransform

Example usage (_via_ `node_modules`):

``` js
import DBFactory from 'indexed-db.es6/es6/DBFactory';
import DatabaseSchema from 'indexed-db.es6/es6/schema/DatabaseSchema';
import ObjectStoreSchema from 'indexed-db.es6/es6/schema/ObjectStoreSchema';
import IndexSchema from 'indexed-db.es6/es6/schema/IndexSchema';
import BatmansCave from './BatmansCave';

class BatmanWeapons extends BatmanCave {
    ...
}
```

Error message

``` sh
ParseError: 'import' and 'export' may appear only with 'sourceType: module'
```

---

:white_check_mark: Tested successfully with [browserify](https://github.com/substack/node-browserify) `11.0.1`.
